### PR TITLE
Set C++20 Standard for ends_with. Support on Case-Sensitive OS.

### DIFF
--- a/IE17-Client/CMakeLists.txt
+++ b/IE17-Client/CMakeLists.txt
@@ -6,6 +6,10 @@ project(IE17Client LANGUAGES CXX)
 # Set the target platform version
 set(CMAKE_SYSTEM_VERSION 10.0)
 
+# Set C++ standard to C++20
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Include sub-projects.
 #add_subdirectory ("Deps/minhook")include(FetchContent)
 

--- a/IE17-Client/player.h
+++ b/IE17-Client/player.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <string>
-#include <Windows.h>
+#include <windows.h>
 
 extern unsigned __int64 localplayer;
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 
 <h1 align="center">IE17</h1>
 
-IE17 is a project aimed to reverse enginner some functions from Ghostbusters The Video Game Remaster.
+IE17 is a project aimed to reverse engineer some functions from Ghostbusters The Video Game Remastered.
 
-This project was made aimed to learn C++ and reverse engineering. Also I want to clarify the code might be poorly written
+This project was made aimed to learn C++ and reverse engineering. Also I want to clarify the code might be poorly written.


### PR DESCRIPTION
- Fix compilation issue on case-sensitive operating systems.
- Set C++ standard to C++20 for supporting the ends_with function.