### PR TITLE
Update

### DIFF
--- a/IE17-Client/main.cpp
+++ b/IE17-Client/main.cpp
@@ -12,8 +12,7 @@
 
 using namespace std;
 
-bool holsterBool = false;
-bool keyholsterPressed = false;
+bool holsterStatus = false;
 int eGogglesStatus = 0;
 bool fakePossessionStatus = false;
 
@@ -118,12 +117,11 @@ void HandleKeyPresses()
 			if (localplayer != 0) {  // Call the function only if localplayer value is set
 				g_modBase = (char*)GetModuleHandle(NULL);  // Update g_modBase value
 				if (!fakePossessionStatus) {
-					fakePossessionStatus = true;
-					fakePossession(localplayer, fakePossessionStatus);
+					fakePossession(localplayer, true);
 				} else {
-					fakePossessionStatus = false;
-					fakePossession(localplayer, fakePossessionStatus);
+					fakePossession(localplayer, false);
 				}
+				fakePossessionStatus = !fakePossessionStatus;
 				Sleep(500);  // Prevent multiple triggers within a short time
 			}
         }
@@ -150,24 +148,16 @@ void HandleKeyPresses()
 			getPlayer();  // Try to update localplayer value
 			if (localplayer != 0) {  // Call the function only if localplayer value is set
 				g_modBase = (char*)GetModuleHandle(NULL);  // Update g_modBase value
-				if (!keyholsterPressed) { 
-					keyholsterPressed = true;
-
-					if (holsterBool) {
-						readyInventoryItem(localplayer, eInventoryNothing, true);
-					   // setGoggleLocation(localplayer, eGogglesOnHead);
-					}
-					else {
-						readyInventoryItem(localplayer, eInventoryProtonGun, true);
-						//setGoggleLocation(localplayer, eGogglesOnFace);
-					}
-
-					holsterBool = !holsterBool;
+				if (!holsterStatus) {
+					readyInventoryItem(localplayer, eInventoryNothing, true);
+				   // setGoggleLocation(localplayer, eGogglesOnHead);
 				}
+				else {
+					readyInventoryItem(localplayer, eInventoryProtonGun, true);
+					//setGoggleLocation(localplayer, eGogglesOnFace);
+				}
+				holsterStatus = !holsterStatus;
             }
-        }
-        else {
-            keyholsterPressed = false;
         }
         // You can check other key presses here in a similar manner
         Sleep(10);  // Small delay to avoid high CPU usage
@@ -419,6 +409,7 @@ void HandleInput()
         {
             cout << "Unknown command. Type 'help' for a list of commands.\n";
         }
+        Sleep(10);  // Small delay to avoid high CPU usage
     }
 }
 

--- a/IE17-Client/main.cpp
+++ b/IE17-Client/main.cpp
@@ -13,7 +13,9 @@
 using namespace std;
 
 bool holsterBool = false;
-bool keyholsterPressed = false;  
+bool keyholsterPressed = false;
+int eGogglesStatus = 0;
+bool fakePossessionStatus = false;
 
 bool m_about = false;
 bool m_legacycrash = false;
@@ -102,39 +104,73 @@ void HandleKeyPresses()
             Sleep(500);  // Prevent multiple triggers within a short time
         }
         else if (GetAsyncKeyState('E') & 1) {
-            setFlashlightMode(localplayer, eFlashlightModeNormal);
-            Sleep(500);  // Prevent multiple triggers within a short time
+			localplayer = 0;  // Clear localplayer value from previous state
+			getPlayer();  // Try to update localplayer value
+			if (localplayer != 0) {  // Call the function only if localplayer value is set
+				g_modBase = (char*)GetModuleHandle(NULL);  // Update g_modBase value
+				setFlashlightMode(localplayer, eFlashlightModeNormal);
+				Sleep(500);  // Prevent multiple triggers within a short time
+			}
         }
         else if (GetAsyncKeyState('P') & 1) {
-            fakePossession(localplayer, true);
-            Sleep(500);  // Prevent multiple triggers within a short time
+			localplayer = 0;  // Clear localplayer value from previous state
+			getPlayer();  // Try to update localplayer value
+			if (localplayer != 0) {  // Call the function only if localplayer value is set
+				g_modBase = (char*)GetModuleHandle(NULL);  // Update g_modBase value
+				if (!fakePossessionStatus) {
+					fakePossessionStatus = true;
+					fakePossession(localplayer, fakePossessionStatus);
+				} else {
+					fakePossessionStatus = false;
+					fakePossession(localplayer, fakePossessionStatus);
+				}
+				Sleep(500);  // Prevent multiple triggers within a short time
+			}
         }
         else if (GetAsyncKeyState('G') & 1) {
-            setGoggleLocation(localplayer, eGogglesOnBelt);
-            Sleep(500);  // Prevent multiple triggers within a short time
+			localplayer = 0;  // Clear localplayer value from previous state
+			getPlayer();  // Try to update localplayer value
+			if (localplayer != 0) {  // Call the function only if localplayer value is set
+				g_modBase = (char*)GetModuleHandle(NULL);  // Update g_modBase value
+				if (eGogglesStatus == 0) {
+					eGogglesStatus = eGogglesOnFace;
+					setGoggleLocation(localplayer, eGogglesOnFace);
+				} else if (eGogglesStatus == 1) {
+					eGogglesStatus = eGogglesOnBelt;
+					setGoggleLocation(localplayer, eGogglesOnBelt);
+				} else if (eGogglesStatus == 2) {
+					eGogglesStatus = eGogglesOnHead;
+					setGoggleLocation(localplayer, eGogglesOnHead);
+				}
+				Sleep(500);  // Prevent multiple triggers within a short time
+			}
         }
-        // You can check other key presses here in a similar manner
-        Sleep(10);  // Small delay to avoid high CPU usage
+        else if (GetAsyncKeyState('Q') & 0x8000) { 
+			localplayer = 0;  // Clear localplayer value from previous state
+			getPlayer();  // Try to update localplayer value
+			if (localplayer != 0) {  // Call the function only if localplayer value is set
+				g_modBase = (char*)GetModuleHandle(NULL);  // Update g_modBase value
+				if (!keyholsterPressed) { 
+					keyholsterPressed = true;
 
-        if (GetAsyncKeyState('Q') & 0x8000) { 
-            if (!keyholsterPressed) { 
-                keyholsterPressed = true;
+					if (holsterBool) {
+						readyInventoryItem(localplayer, eInventoryNothing, true);
+					   // setGoggleLocation(localplayer, eGogglesOnHead);
+					}
+					else {
+						readyInventoryItem(localplayer, eInventoryProtonGun, true);
+						//setGoggleLocation(localplayer, eGogglesOnFace);
+					}
 
-                if (holsterBool) {
-                    readyInventoryItem(localplayer, eInventoryNothing, true);
-                   // setGoggleLocation(localplayer, eGogglesOnHead);
-                }
-                else {
-                    readyInventoryItem(localplayer, eInventoryProtonGun, true);
-                    //setGoggleLocation(localplayer, eGogglesOnFace);
-                }
-
-                holsterBool = !holsterBool;
+					holsterBool = !holsterBool;
+				}
             }
         }
         else {
             keyholsterPressed = false;
         }
+        // You can check other key presses here in a similar manner
+        Sleep(10);  // Small delay to avoid high CPU usage
     }
 }
 

--- a/IE17-Client/player.cpp
+++ b/IE17-Client/player.cpp
@@ -156,5 +156,6 @@ void MonitorLevel() {
                 getPlayer(); // call getPlayer if level ends with .lvl
             }
         }
+        Sleep(10);  // Small delay to avoid high CPU usage
     }
 }


### PR DESCRIPTION
- Fixed issues causing crashes when certain values weren’t set or updated:
    Clear localplayer value from previous state.
    Try to update localplayer value.
    Call the function only if localplayer value is set.
    Update g_modBase value.

- You can now toggle fakePossession between true and false.

- You can now toggle setGoggleLocation between the following states:
    eGogglesOnFace
    eGogglesOnBelt
    eGogglesOnHead

- Simplified holster toggle logic.

- Added small delay to while true loops to avoid high CPU usage.
